### PR TITLE
Improve workflow and notebook logs to include the run URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,19 @@ pip install astro-provider-databricks
    
 4. [Create a Databricks connection in Airflow](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html). This can be done by running the following command, replacing the login and password (with your access token):
 
-```shell
-# If using Airflow 2.3 or higher:
-airflow connections add 'databricks_conn' \
-    --conn-json '{
-        "conn_type": "databricks",
-        "login": "some.email@yourcompany.com",
-        "host": "https://dbc-c9390870-65ef.cloud.databricks.com/",
-        "password": "personal-access-token"
-    }'
-
-# If using Airflow between 2.2.4 and less than 2.3:
-airflow connections add 'databricks_conn' --conn-type 'databricks' --conn-login 'some.email@yourcompany.com' --conn-host 'https://dbc-9c390870-65ef.cloud.databricks.com/' --conn-password 'personal-access-token'
-```
+   ```shell
+   # If using Airflow 2.3 or higher:
+   airflow connections add 'databricks_conn' \
+       --conn-json '{
+           "conn_type": "databricks",
+           "login": "some.email@yourcompany.com",
+           "host": "https://dbc-c9390870-65ef.cloud.databricks.com/",
+           "password": "personal-access-token"
+       }'
+   
+   # If using Airflow between 2.2.4 and less than 2.3:
+   airflow connections add 'databricks_conn' --conn-type 'databricks' --conn-login 'some.email@yourcompany.com' --conn-host 'https://dbc-9c390870-65ef.cloud.databricks.com/' --conn-password 'personal-access-token'
+   ```
 
 5. Copy the following workflow into a file named `example_databricks_workflow.py` and add it to the `dags` directory of your Airflow project:
    
@@ -77,7 +77,13 @@ airflow connections add 'databricks_conn' --conn-type 'databricks' --conn-login 
     airflow dags test example_databricks_workflow `date -Iseconds`
     ```
    
-This will create a Databricks Workflow with two Notebook jobs. This workflow may take two minutes to complete if the cluster is already up & running or approximately five minutes depending on your cluster initialisation time.
+    Which will log, among other lines, the link to the Databricks Job Run URL:
+    ```sh
+    [2023-03-13 15:27:09,934] {notebook.py:158} INFO - Check the job run in Databricks: https://dbc-c9390870-65ef.cloud.databricks.com/?o=4256138892007661#job/950578808520081/run/14940832
+    ```
+   
+    This will create a Databricks Workflow with two Notebook jobs. This workflow may take two minutes to complete if the cluster is already up & running or approximately five minutes depending on your cluster initialisation time.
+ 
 
 ## Available features
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ pip install astro-provider-databricks
 
    Alternatively, you can download `example_databricks_workflow.py`
    ```shell
-    curl -O https://raw.githubusercontent.com/astronomer/astro-provider-databricks/main/example_dags/example_databricks_workflow.py
+   curl -O https://raw.githubusercontent.com/astronomer/astro-provider-databricks/main/example_dags/example_databricks_workflow.py
    ```
 
 6. Run the example DAG:
 
-    ```sh
+    ```shell
     airflow dags test example_databricks_workflow `date -Iseconds`
     ```
    
     Which will log, among other lines, the link to the Databricks Job Run URL:
-    ```sh
+    ```shell
     [2023-03-13 15:27:09,934] {notebook.py:158} INFO - Check the job run in Databricks: https://dbc-c9390870-65ef.cloud.databricks.com/?o=4256138892007661#job/950578808520081/run/14940832
     ```
    

--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -153,8 +153,8 @@ class DatabricksNotebookOperator(BaseOperator):
         api_client = self._get_api_client()
         runs_api = RunsApi(api_client)
         current_task = self._get_current_databricks_task(runs_api)
-
-        self.log.info(f"Check the job run in Databricks: {current_task['run_page_url']}")
+        url = runs_api.get_run(self.databricks_run_id, version=JOBS_API_VERSION)['run_page_url']
+        self.log.info(f"Check the job run in Databricks: {url}")
         self._wait_for_pending_task(current_task, runs_api)
         self._wait_for_running_task(current_task, runs_api)
         self._wait_for_terminating_task(current_task, runs_api)

--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -93,6 +93,7 @@ class DatabricksNotebookOperator(BaseOperator):
         self.notebook_params = notebook_params or {}
         self.notebook_packages = notebook_packages or []
         self.databricks_conn_id = databricks_conn_id
+        self.databricks_run_id = ""
         self.databricks_metadata: dict | None = None
         self.job_cluster_key = job_cluster_key or ""
         self.new_cluster = new_cluster or {}
@@ -152,6 +153,8 @@ class DatabricksNotebookOperator(BaseOperator):
         api_client = self._get_api_client()
         runs_api = RunsApi(api_client)
         current_task = self._get_current_databricks_task(runs_api)
+
+        self.log.info(f"Check the job run in Databricks: {current_task['run_page_url']}")
         self._wait_for_pending_task(current_task, runs_api)
         self._wait_for_running_task(current_task, runs_api)
         self._wait_for_terminating_task(current_task, runs_api)

--- a/src/astro_databricks/operators/workflow.py
+++ b/src/astro_databricks/operators/workflow.py
@@ -31,7 +31,6 @@ from astro_databricks.plugins.plugin import (
     DatabricksJobRunLink,
 )
 
-
 @define
 class DatabricksMetaData:
     databricks_conn_id: str
@@ -166,11 +165,13 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
             spark_submit_params=self.task_group.spark_submit_params,
         )["run_id"]
         runs_api = RunsApi(api_client)
-
+        url = runs_api.get_run(run_id)["run_page_url"]
+        self.log.info(f"Check the job run in Databricks: {url}")
         while runs_api.get_run(run_id)["state"]["life_cycle_state"] == "PENDING":
             print("job pending")
             time.sleep(5)
         self.databricks_run_id = run_id
+
         return {
             "databricks_conn_id": self.databricks_conn_id,
             "databricks_job_id": job_id,

--- a/src/astro_databricks/operators/workflow.py
+++ b/src/astro_databricks/operators/workflow.py
@@ -165,7 +165,7 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
             spark_submit_params=self.task_group.spark_submit_params,
         )["run_id"]
         runs_api = RunsApi(api_client)
-        url = runs_api.get_run(run_id)["run_page_url"]
+        url = runs_api.get_run(run_id).get("run_page_url")
         self.log.info(f"Check the job run in Databricks: {url}")
         while runs_api.get_run(run_id)["state"]["life_cycle_state"] == "PENDING":
             print("job pending")

--- a/tests/databricks/test_notebook.py
+++ b/tests/databricks/test_notebook.py
@@ -357,6 +357,7 @@ def test_monitor_databricks_job_success(
     mock_runs_api,
     mock_databricks_hook,
     databricks_notebook_operator,
+    caplog
 ):
     mock_get_databricks_task_id.return_value = "1"
     # Define the expected response
@@ -381,6 +382,7 @@ def test_monitor_databricks_job_success(
     mock_runs_api.return_value.get_run.assert_called_with(
         databricks_notebook_operator.databricks_run_id, version="2.1"
     )
+    assert 'Check the job run in Databricks: https://databricks-instance-xyz.cloud.databricks.com/#job/1234/run/1' in caplog.messages
 
 
 @mock.patch("astro_databricks.operators.notebook.DatabricksHook")


### PR DESCRIPTION
Before this change, if the user were only using the command line, they could not easily identify the Databricks Workflow Job URL.