### PR TITLE
Improve running example DAGs locally

### DIFF
--- a/dev/dags/task_group_example.py
+++ b/dev/dags/task_group_example.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from airflow.decorators import dag, task_group
-
 from astro_databricks.operators.notebook import DatabricksNotebookOperator
 from astro_databricks.operators.workflow import DatabricksWorkflowTaskGroup
 
@@ -48,12 +47,12 @@ def task_group_example():
             notebook_path="/Shared/Notebook_1",
             source="WORKSPACE",
             job_cluster_key="Shared_job_cluster",
-            notebook_packages=[{"pypi": {"package": "Faker"}}]
+            notebook_packages=[{"pypi": {"package": "Faker"}}],
         )
 
         @task_group
         def my_task_group():
-            nb_2 = DatabricksNotebookOperator(
+            DatabricksNotebookOperator(
                 task_id="nb_2",
                 databricks_conn_id="databricks_default",
                 notebook_path="/Shared/Notebook_2",
@@ -61,7 +60,7 @@ def task_group_example():
                 job_cluster_key="Shared_job_cluster",
             )
 
-            nb_3 = DatabricksNotebookOperator(
+            DatabricksNotebookOperator(
                 task_id="nb_3",
                 databricks_conn_id="databricks_default",
                 notebook_path="/Shared/Notebook_3",

--- a/example_dags/example_databricks_notebook.py
+++ b/example_dags/example_databricks_notebook.py
@@ -32,9 +32,10 @@ NEW_CLUSTER_SPEC = {
     "runtime_engine": "STANDARD",
     "num_workers": 8,
 }
+USER = os.environ.get("USER")
 
 dag = DAG(
-    dag_id="example_databricks_notebook",
+    dag_id=f"example_databricks_notebook_{USER}",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,

--- a/example_dags/example_databricks_workflow.py
+++ b/example_dags/example_databricks_workflow.py
@@ -22,6 +22,8 @@ DATABRICKS_DESTINATION_ID = os.getenv(
     "ASTRO_DATABRICKS_DESTINATION_ID", "b0aea8ab-ea8c-4a45-a2e9-9a26753fd702"
 )
 GROUP_ID = os.getenv("DATABRICKS_GROUP_ID", "1234").replace(".", "_")
+USER = os.environ.get("USER")
+
 job_cluster_spec = [
     {
         "job_cluster_key": "Shared_job_cluster",
@@ -55,7 +57,7 @@ dag = DAG(
 with dag:
     # [START howto_databricks_workflow_notebook]
     task_group = DatabricksWorkflowTaskGroup(
-        group_id=f"test_workflow_{GROUP_ID}",
+        group_id=f"test_workflow_{USER}_{GROUP_ID}",
         databricks_conn_id=DATABRICKS_CONN_ID,
         job_clusters=job_cluster_spec,
         notebook_params=[],


### PR DESCRIPTION
Change the examples DAGs' Databricks Job IDs to include the username so different developers trigger different jobs when running these DAGs locally.