### PR TITLE
Fix copying dependencies from task groups to notebooks (with inner task groups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
         with:
           python-version: '3.9'
           architecture: 'x64'
-      #- uses: actions/cache@v3
-      #  with:
-      #    path: |
-      #      ~/.cache/pip
-      #      .nox
-      #    key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - run: pip3 install nox packaging
       - run: nox -s build_docs
 
@@ -105,12 +105,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
-      #- uses: actions/cache@v3
-      #  with:
-      #    path: |
-      #      ~/.cache/pip
-      #      .nox
-      #    key: unit-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: unit-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: pip3 install nox packaging
       - run: nox -s "test-${{ matrix.python }}(airflow='${{ matrix.airflow }}')" -- --ignore "tests/test_example_dags.py" --cov-report=xml
       - name: Upload coverage
@@ -154,12 +154,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
-      #- uses: actions/cache@v3
-      #  with:
-      #    path: |
-      #      ~/.cache/pip
-      #      .nox
-      #    key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox packaging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
         with:
           python-version: '3.9'
           architecture: 'x64'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            .nox
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+      #- uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      ~/.cache/pip
+      #      .nox
+      #    key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - run: pip3 install nox packaging
       - run: nox -s build_docs
 
@@ -105,12 +105,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            .nox
-          key: unit-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
+      #- uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      ~/.cache/pip
+      #      .nox
+      #    key: unit-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: pip3 install nox packaging
       - run: nox -s "test-${{ matrix.python }}(airflow='${{ matrix.airflow }}')" -- --ignore "tests/test_example_dags.py" --cov-report=xml
       - name: Upload coverage
@@ -154,12 +154,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            .nox
-          key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
+      #- uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      ~/.cache/pip
+      #      .nox
+      #    key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox packaging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 #            ~/.cache/pip
 #            .nox
 #          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-#      - run: pip3 install nox
+#      - run: pip3 install nox packaging
 #      - run: nox -s type_check
 
   Build-Docs:
@@ -69,7 +69,7 @@ jobs:
             ~/.cache/pip
             .nox
           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-      - run: pip3 install nox
+      - run: pip3 install nox packaging
       - run: nox -s build_docs
 
   Run-Unit-Tests:
@@ -111,7 +111,7 @@ jobs:
             ~/.cache/pip
             .nox
           key: unit-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
-      - run: pip3 install nox
+      - run: pip3 install nox packaging
       - run: nox -s "test-${{ matrix.python }}(airflow='${{ matrix.airflow }}')" -- --ignore "tests/test_example_dags.py" --cov-report=xml
       - name: Upload coverage
         uses: actions/upload-artifact@v2
@@ -162,7 +162,7 @@ jobs:
           key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
-      - run: pip3 install nox
+      - run: pip3 install nox packaging
       - run: DATABRICKS_GROUP_ID="${{github.run_id}}_${{matrix.python}}_${{matrix.airflow}}" nox -s "test-${{ matrix.python }}(airflow='${{ matrix.airflow }}')" -- "tests/test_example_dags.py" --cov-report=xml
       - name: Upload coverage
         uses: actions/upload-artifact@v2

--- a/example_dags/example_task_group.py
+++ b/example_dags/example_task_group.py
@@ -5,6 +5,9 @@ from astro_databricks.operators.notebook import DatabricksNotebookOperator
 from astro_databricks.operators.workflow import DatabricksWorkflowTaskGroup
 
 DATABRICKS_CONN = "databricks_conn"
+USER = os.environ.get("USER")
+GROUP_ID = os.getenv("DATABRICKS_GROUP_ID", "1234").replace(".", "_")
+USER = os.environ.get("USER")
 job_clusters = [
     {
         "job_cluster_key": "Shared_job_cluster",
@@ -38,7 +41,7 @@ job_clusters = [
 )
 def example_task_group():
     with DatabricksWorkflowTaskGroup(
-        group_id="example_task_group",
+        group_id=f"example_task_group_{USER}_{GROUP_ID}",
         databricks_conn_id=DATABRICKS_CONN,
         job_clusters=job_clusters,
         notebook_packages=[{"pypi": {"package": "simplejson"}}],

--- a/example_dags/example_task_group.py
+++ b/example_dags/example_task_group.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task_group
+from astro_databricks.operators.notebook import DatabricksNotebookOperator
+from astro_databricks.operators.workflow import DatabricksWorkflowTaskGroup
+
+DATABRICKS_CONN = "databricks_conn"
+job_clusters = [
+    {
+        "job_cluster_key": "Shared_job_cluster",
+        "new_cluster": {
+            "cluster_name": "",
+            "spark_version": "11.3.x-scala2.12",
+            "aws_attributes": {
+                "first_on_demand": 1,
+                "availability": "SPOT_WITH_FALLBACK",
+                "zone_id": "us-east-2b",
+                "spot_bid_price_percent": 100,
+                "ebs_volume_count": 0,
+            },
+            "node_type_id": "i3.xlarge",
+            "spark_env_vars": {"PYSPARK_PYTHON": "/databricks/python3/bin/python3"},
+            "enable_elastic_disk": False,
+            "data_security_mode": "LEGACY_SINGLE_USER_STANDARD",
+            "runtime_engine": "STANDARD",
+            "num_workers": 8,
+        },
+    }
+]
+
+
+@dag(
+    schedule_interval="@daily",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=["astro-provider-databricks"],
+
+)
+def example_task_group():
+    with DatabricksWorkflowTaskGroup(
+        group_id="example_task_group",
+        databricks_conn_id=DATABRICKS_CONN,
+        job_clusters=job_clusters,
+        notebook_packages=[{"pypi": {"package": "simplejson"}}],
+    ):
+        nb_1 = DatabricksNotebookOperator(
+            task_id="nb_1",
+            databricks_conn_id=DATABRICKS_CONN,
+            notebook_path="/Shared/Notebook_1",
+            source="WORKSPACE",
+            job_cluster_key="Shared_job_cluster",
+            notebook_packages=[{"pypi": {"package": "Faker"}}],
+        )
+
+        @task_group
+        def my_task_group():
+            DatabricksNotebookOperator(
+                task_id="nb_2",
+                databricks_conn_id=DATABRICKS_CONN,
+                notebook_path="/Shared/Notebook_2",
+                source="WORKSPACE",
+                job_cluster_key="Shared_job_cluster",
+            )
+
+            DatabricksNotebookOperator(
+                task_id="nb_3",
+                databricks_conn_id=DATABRICKS_CONN,
+                notebook_path="/Shared/Notebook_3",
+                source="WORKSPACE",
+                job_cluster_key="Shared_job_cluster",
+            )
+
+        nb_4 = DatabricksNotebookOperator(
+            task_id="nb_4",
+            databricks_conn_id=DATABRICKS_CONN,
+            notebook_path="/Shared/Notebook_4",
+            source="WORKSPACE",
+            job_cluster_key="Shared_job_cluster",
+        )
+
+        nb_1 >> my_task_group() >> nb_4
+
+
+example_task_group()

--- a/example_dags/example_task_group.py
+++ b/example_dags/example_task_group.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 from airflow.decorators import dag, task_group

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import nox
+from packaging import version
 
 nox.options.sessions = ["dev"]
 nox.options.reuse_existing_virtualenvs = True
@@ -36,8 +37,13 @@ def test(session: nox.Session, airflow) -> None:
         "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow\\.* astro\\.* astro_databricks\\.*",
     }
 
+    if version.parse(airflow) < version.parse("2.4"):
+        session.install("apache-airflow-providers-databricks<4.2")
+
     session.install("-e", ".[tests]")
     session.install(f"apache-airflow=={airflow}")
+    # Workaround to the issue:
+    # RuntimeError: The package `apache-airflow-providers-databricks:4.2.0` requires Apache Airflow 2.4.0+
 
     # Log all the installed dependencies
     session.log("Installed Dependencies:")

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,13 +37,13 @@ def test(session: nox.Session, airflow) -> None:
         "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow\\.* astro\\.* astro_databricks\\.*",
     }
 
+    # Workaround to the issue:
+    # RuntimeError: The package `apache-airflow-providers-databricks:4.2.0` requires Apache Airflow 2.4.0+
     if version.parse(airflow) < version.parse("2.4"):
         session.install("apache-airflow-providers-databricks<4.2")
 
     session.install("-e", ".[tests]")
     session.install(f"apache-airflow=={airflow}")
-    # Workaround to the issue:
-    # RuntimeError: The package `apache-airflow-providers-databricks:4.2.0` requires Apache Airflow 2.4.0+
 
     # Log all the installed dependencies
     session.log("Installed Dependencies:")

--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import time
 from typing import Any
 
+import airflow
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.utils.context import Context
+from airflow.utils.task_group import TaskGroup
 from databricks_cli.runs.api import RunsApi
 from databricks_cli.sdk.api_client import ApiClient
 
@@ -129,9 +131,10 @@ class DatabricksNotebookOperator(BaseOperator):
             "libraries": self.notebook_packages,
         }
 
-    def merge_notebook_packages(self):
+    def merge_notebook_packages(self, databricks_task_group: TaskGroup):
         """
         Merge the task group notebook packages into the notebook's packages, without adding any identical duplicates.
+        Modifies self.notebook_packages in place.
 
         Example value for self.notebook_packages:
         [
@@ -139,7 +142,7 @@ class DatabricksNotebookOperator(BaseOperator):
         ]
 
         """
-        for task_group_package in self.databricks_task_group.notebook_packages:
+        for task_group_package in databricks_task_group.notebook_packages:
             exists = False
             for existing_package in self.notebook_packages:
                 if task_group_package == existing_package:
@@ -148,25 +151,38 @@ class DatabricksNotebookOperator(BaseOperator):
             if not exists:
                 self.notebook_packages.append(task_group_package)
 
+    def find_parent_databricks_workflow_task_group(self):
+        """
+        Find the closest parent_group which is an instance of DatabricksWorkflowTaskGroup.
+
+        In the case of Airflow 2.2.4, inner Task Groups do not inherit properties from Parent Task Groups like more
+        recent versions of Airflow. This lead to the issue:
+        https://github.com/astronomer/astro-provider-databricks/pull/47
+        """
+        parent_group = self.task_group
+        while parent_group:
+            if parent_group.__class__.__name__ == "DatabricksWorkflowTaskGroup":
+                return parent_group
+            parent_group = parent_group._parent_group
+
     def convert_to_databricks_workflow_task(
         self, relevant_upstreams: list[BaseOperator], context: Context | None = None
     ):
         """
         Convert the operator to a Databricks workflow task that can be a task in a workflow
         """
-        if self.databricks_task_group and hasattr(
-            self.databricks_task_group,
-            "notebook_packages",
-        ):
-            self.merge_notebook_packages()
+        if airflow.__version__ == "2.2.4":
+            databricks_task_group = self.find_parent_databricks_workflow_task_group()
+        else:
+            databricks_task_group = self.databricks_task_group
 
-        if self.databricks_task_group and hasattr(
-            self.databricks_task_group,
-            "notebook_params",
-        ):
+        if databricks_task_group and hasattr(databricks_task_group, "notebook_packages"):
+            self.merge_notebook_packages(databricks_task_group)
+
+        if databricks_task_group and hasattr(databricks_task_group, "notebook_params"):
             self.notebook_params = {
                 **self.notebook_params,
-                **self.databricks_task_group.notebook_params,
+                **databricks_task_group.notebook_params,
             }
         if context:
             # The following exception currently only happens on Airflow 2.3, with the following error:

--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -155,7 +155,7 @@ class DatabricksNotebookOperator(BaseOperator):
         """
         Find the closest parent_group which is an instance of DatabricksWorkflowTaskGroup.
 
-        In the case of Airflow 2.2.4, inner Task Groups do not inherit properties from Parent Task Groups like more
+        In the case of Airflow 2.2.x, inner Task Groups do not inherit properties from Parent Task Groups like more
         recent versions of Airflow. This lead to the issue:
         https://github.com/astronomer/astro-provider-databricks/pull/47
         """
@@ -171,7 +171,7 @@ class DatabricksNotebookOperator(BaseOperator):
         """
         Convert the operator to a Databricks workflow task that can be a task in a workflow
         """
-        if airflow.__version__ == "2.2.4":
+        if airflow.__version__ in ("2.2.4", "2.2.5"):
             databricks_task_group = self.find_parent_databricks_workflow_task_group()
         else:
             databricks_task_group = self.databricks_task_group


### PR DESCRIPTION
 Before this change, `DatabricksWorkflowTaskGroup` (`astro-provider-databricks==0.1.3`) did not pass Python dependencies to inner Databricks tasks if they were inside intermediate Airflow Task Groups for Airflow 2.2.4. For newer Airflow versions, it duplicated the dependencies proportionally to the amount of nested `TaskGroup`s.

In the example, DAG introduced:
- notebooks 1, 2, 3 and 4 need the `simplejson` dependency
- the `simplejson` dependency is only set at the `DatabricksWorkflowTaskGroup` level (`example_task_group`)
- notebooks 2 and 3 are inside an inner Airflow `TaskGroup` (`my_task_group`)

<img width="642" alt="Screenshot 2023-06-14 at 16 52 59" src="https://github.com/astronomer/astro-provider-databricks/assets/272048/f3c69dcb-d984-44d7-a3eb-7954c833c65c">

We confirmed the Databricks cluster does not have `simplejson` as a dependency:
<img width="869" alt="Screenshot 2023-06-14 at 16 45 10" src="https://github.com/astronomer/astro-provider-databricks/assets/272048/8d72e0ea-d232-4b42-9097-3227e0041788">

And we also confirmed the notebooks failed since the cluster does not have this dependency:
<img width="1032" alt="Screenshot 2023-06-14 at 16 48 07" src="https://github.com/astronomer/astro-provider-databricks/assets/272048/206bb0fa-8a42-40fd-af43-4bc747ab3fd5">

All the tasks from this Databricks Workflow have the `simplejson` dependency in Databricks, both the ones inside the inner task group and the ones outside. Examples:

<img width="850" alt="Screenshot 2023-06-14 at 16 49 41" src="https://github.com/astronomer/astro-provider-databricks/assets/272048/10f010b7-821b-41d2-9cf6-a9ca755eaf14">

<img width="838" alt="Screenshot 2023-06-14 at 16 49 55" src="https://github.com/astronomer/astro-provider-databricks/assets/272048/9fa403d3-6937-470c-b7f0-7e45518ad431">



