### PR TITLE
Remove retries from example DAGS (users should use repair)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           path: |
             ~/.cache/pip
             .nox
-          key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
+          key: example-dags-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('pyproject.toml') }}-nox-${{ hashFiles('noxfile.py') }}-version-${{ hashFiles('src/astro_databricks/__init__.py') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox packaging

--- a/example_dags/example_databricks_notebook.py
+++ b/example_dags/example_databricks_notebook.py
@@ -9,6 +9,7 @@ from astro_databricks import DatabricksNotebookOperator
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    # Users are encouraged to use the repair feature, retries may fail:
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 0)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }

--- a/example_dags/example_databricks_notebook.py
+++ b/example_dags/example_databricks_notebook.py
@@ -9,7 +9,7 @@ from astro_databricks import DatabricksNotebookOperator
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
-    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 0)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 

--- a/example_dags/example_databricks_workflow.py
+++ b/example_dags/example_databricks_workflow.py
@@ -9,6 +9,7 @@ from astro_databricks import DatabricksNotebookOperator, DatabricksWorkflowTaskG
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    # Users are encouraged to use the repair feature, retries may fail:
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 0)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }

--- a/example_dags/example_databricks_workflow.py
+++ b/example_dags/example_databricks_workflow.py
@@ -9,7 +9,7 @@ from astro_databricks import DatabricksNotebookOperator, DatabricksWorkflowTaskG
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
-    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 0)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 

--- a/example_dags/example_task_group.py
+++ b/example_dags/example_task_group.py
@@ -40,7 +40,7 @@ job_clusters = [
     schedule_interval="@daily",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    default_args={'retries': 0},
+    default_args={'retries': 0},  # Users are encouraged to use the repair feature, retries may fail
     tags=["astro-provider-databricks"],
 )
 def example_task_group():

--- a/example_dags/example_task_group.py
+++ b/example_dags/example_task_group.py
@@ -40,8 +40,8 @@ job_clusters = [
     schedule_interval="@daily",
     start_date=datetime(2021, 1, 1),
     catchup=False,
+    default_args={'retries': 0},
     tags=["astro-provider-databricks"],
-
 )
 def example_task_group():
     databricks_task_group = DatabricksWorkflowTaskGroup(

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,6 @@ import nox
 from packaging import version
 
 nox.options.sessions = ["dev"]
-nox.options.reuse_existing_virtualenvs = True
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,8 +6,8 @@ import nox
 from packaging import version
 
 nox.options.sessions = ["dev"]
-nox.options.reuse_existing_virtualenvs = True
-nox.options.error_on_external_run = False
+# nox.options.reuse_existing_virtualenvs = True
+# nox.options.error_on_external_run = False
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,8 @@ import nox
 from packaging import version
 
 nox.options.sessions = ["dev"]
+nox.options.reuse_existing_virtualenvs = True
+nox.options.error_on_external_run = False
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,8 +6,8 @@ import nox
 from packaging import version
 
 nox.options.sessions = ["dev"]
+nox.options.error_on_external_run = False
 # nox.options.reuse_existing_virtualenvs = True
-# nox.options.error_on_external_run = False
 
 
 @nox.session(python="3.10")


### PR DESCRIPTION
Retries can lead to issues in the current implementation, especially if the previous job execution has not yet been finished.
If users have issues, they are encouraged to use the `repair` feature.