### PR TITLE
Fix repairing tasks declared in inner task groups

### DIFF
--- a/src/astro_databricks/plugins/plugin.py
+++ b/src/astro_databricks/plugins/plugin.py
@@ -140,14 +140,13 @@ def _repair_task(
         )
 
     api_client = _get_api_client()
-
     log.debug("Getting latest repair ID")
     jobs_service = JobsService(api_client)
     current_job = jobs_service.get_run(run_id=databricks_run_id, include_history=True)
     repair_history = current_job.get("repair_history")
     repair_history_id = None
     if (
-            repair_history and len(repair_history) > 1
+        repair_history and len(repair_history) > 1
     ):  # We use >1 because the first entry is the original run.
         # We use the last item in the array to get the latest repair ID
         repair_history_id = repair_history[-1]["id"]


### PR DESCRIPTION
Fix two problems with the repair feature, related to the following buttons:
* **Repair All Failed Tasks** did not repair tasks inside an  inner `TaskGroup`
* **Repair a single failed task** was disabled if tasks were inside an inner `TaskGroup`

A customer reported these problems, and this behaviour happened with all Airflow versions (from 2.2.4 until 2.6)

This change was validated through unit tests and also manually, using Ubuntu 22.x, by following these steps:
* Running Airflow 2.6, as described in our [docs](https://github.com/astronomer/astro-provider-databricks/blob/afd120a10b0b918dc155202601a0285deb664aac/quickstart/without-astro-cli.md). The only difference was that the `astro-provider-databricks` was installed using `pip install -e .[tests]` from the branch `repair-inner-task-group`.
* Triggering the dag `example_task_group` manually
* Going to the Databricks UI and cancelling the task related to the nb3
* Trying out the buttons "Repair All Failed Tasks" and "Repair a single failed task"

The fix for the second issue can be visually seen in this screenshot:
![Screenshot from 2023-06-16 15-26-40](https://github.com/astronomer/astro-provider-databricks/assets/272048/a180cd96-842b-44db-b12b-a3e97a78eb32)

**DIsclaimer**: This change was also tested on Airflow 2.2.4, and observed that when the feature repair is used in this version, the Airflow tasks are not cleared - but the Databricks job is repaired.

