### PR TITLE
Allow pydantic >= 2.0.0 in order to work on Airflow >= 2.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "databricks-cli>=0.17.7",
     "apache-airflow-providers-databricks>=2.2.0",
     "mergedeep",
-    "pydantic>=1.10.0,<2.0.0", # Airflow & Pydantic issue: https://github.com/apache/airflow/issues/32311
+    "pydantic>=1.10.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #60 
I'm not sure how this impacts previous version of Airflow, but I assume (?) that Airflow (<2.8) itself has the restriction on pydantic<2.0.0, so we shouldn't explicitly declare it. 