### PR TITLE
Remove pydantic upper version constraint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ----------------
 
 Version changes 
-* Bump `pydantic` to `>=2.3.0` to be compatible with Airflow 2.7.0+.
+* Bump `pydantic` to `>=1.10.0` to be compatible with Airflow 2.7.0+.
 
 0.1.4 (23-06-16)
 ----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,25 @@ Changelog
 0.1.6 (24-02-23)
 ----------------
 
-Version changes 
-* Bump `pydantic` to `>=1.10.0` to be compatible with Airflow 2.7.0+.
+Bug fixes
+
+* Bump `pydantic` to `>=1.10.0` to be compatible with Airflow 2.7.0+ (PR `#61 <https://github.com/astronomer/astro-provider-databricks/pull/61>`_ by @w0ut0)
+
+
+0.1.5 (31-07-23)
+----------------
+
+Feature
+
+* Add operator that supports all task types (PR `#55 <https://github.com/astronomer/astro-provider-databricks/pull/55>`_ by @crong-k)
+
+Bug fixes
+
+* Limit Pydantic < 2.0.0 until Airflow resolves incompatibilities (PR `#52 <https://github.com/astronomer/astro-provider-databricks/pull/42>`_ by @tatiana)
+
+Enhancements
+
+* Update query ID to hello world query (PR `#56 <https://github.com/astronomer/astro-provider-databricks/pull/56>`_ by @jlaneve)
 
 0.1.4 (23-06-16)
 ----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.1.6 (24-02-23)
+----------------
+
+Version changes 
+* Bump `pydantic` to `>=2.3.0` to be compatible with Airflow 2.7.0+.
+
 0.1.4 (23-06-16)
 ----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "databricks-cli>=0.17.7",
     "apache-airflow-providers-databricks>=2.2.0",
     "mergedeep",
-    "pydantic>=1.10.0,<2.0.0", # Airflow & Pydantic issue: https://github.com/apache/airflow/issues/32311
+    "pydantic>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "databricks-cli>=0.17.7",
     "apache-airflow-providers-databricks>=2.2.0",
     "mergedeep",
-    "pydantic>=2.3.0",
+    "pydantic>=1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/astro_databricks/__init__.py
+++ b/src/astro_databricks/__init__.py
@@ -3,7 +3,7 @@ from astro_databricks.operators.common import DatabricksTaskOperator
 from astro_databricks.operators.notebook import DatabricksNotebookOperator
 from astro_databricks.operators.workflow import DatabricksWorkflowTaskGroup
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __all__ = [
     "DatabricksNotebookOperator",
     "DatabricksWorkflowTaskGroup",


### PR DESCRIPTION
The Airflow issue with pydantic was resolved and 2.8.1 depends on pydantic>=2.3.0: https://github.com/apache/airflow/issues/32311 

I tested the change with my tutorial DAG and does not seem to break anything. :) 