### PR TITLE
Support for existing_cluster_id in DatabricksNotebookOperator

### DIFF
--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -210,6 +210,9 @@ class DatabricksNotebookOperator(BaseOperator):
             **base_task_json,
         }
 
+        if self.existing_cluster_id and self.job_cluster_key:
+            raise ValueError ("Both existing_cluster_id and job_cluster_key are set. Only one cluster can be set per task.")
+        
         if self.existing_cluster_id:
             result['existing_cluster_id'] = self.existing_cluster_id
         elif self.job_cluster_key:

--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -207,9 +207,14 @@ class DatabricksNotebookOperator(BaseOperator):
                 for t in self.upstream_task_ids
                 if t in relevant_upstreams
             ],
-            "job_cluster_key": self.job_cluster_key,
             **base_task_json,
         }
+
+        if self.existing_cluster_id:
+            result['existing_cluster_id'] = self.existing_cluster_id
+        elif self.job_cluster_key:
+            result['job_cluster_key'] = self.job_cluster_key
+
         return result
 
     def _get_databricks_task_id(self, task_id: str):

--- a/tests/databricks/test_workflow.py
+++ b/tests/databricks/test_workflow.py
@@ -421,7 +421,7 @@ def test_create_workflow_from_notebooks_with_different_clusters(
             )
             notebook_1 >> notebook_2
 
-    assert len(task_group.children) == 2
+    assert len(task_group.children) == 3
     task_group.children["test_workflow.launch"].execute(context={})
     mock_jobs_api.return_value.create_job.assert_called_once_with(
         json=expected_workflow_json_existing_cluster_id,

--- a/tests/databricks/test_workflow.py
+++ b/tests/databricks/test_workflow.py
@@ -413,7 +413,6 @@ def test_create_workflow_from_notebooks_with_different_clusters(
                 databricks_conn_id="foo",
                 notebook_path="/foo/bar",
                 source="WORKSPACE",
-                job_cluster_key="foo",
                 existing_cluster_id="foo",
                 notebook_params={
                     "foo": "bar",


### PR DESCRIPTION
When tasks are launched with `DatabricksNotebookOperators` from within a TaskGroup
using the `DatabricksWorkflowTaskGroup`, currently we do not support using `existing_cluster_id`
for those Notebook tasks. The PR addresses this issue by allowing to support 
`existing_cluster_id` in such cases and additionally also keeps supporting the current
`job_cluster_key` approach allowing users to use a combination of both for a workflow.


closes: #70 